### PR TITLE
Fixed the Simulink parameter name to save the time

### DIFF
--- a/src/main/java/org/group_mmm/SimulinkSUL.java
+++ b/src/main/java/org/group_mmm/SimulinkSUL.java
@@ -218,7 +218,7 @@ class SimulinkSUL implements SUL<List<Double>, IOSignalPiece> {
             builder.append("in = in.setModelParameter('SaveOutput', 'on');");
             builder.append("in = in.setModelParameter('OutputSaveName', 'yout');");
             builder.append("in = in.setModelParameter('SaveTime', 'on');");
-            builder.append("in = in.setModelParameter('OutputTimeName', 'tout');");
+            builder.append("in = in.setModelParameter('TimeSaveName', 'tout');");
         }
         builder.append("in = in.setModelParameter('LoadInitialState', 'off');");
 


### PR DESCRIPTION
The source of information is here: https://jp.mathworks.com/help/simulink/gui/time.html

## Summary of the changes

* Fixed the Simulink parameter name to save the timing information, i.e., `tout`
    * According to the official document (https://www.mathworks.com/help/simulink/gui/time.html), we should use `TimeSaveName`.

## Checklist

* [X] Are the contributors appropriately acknowledged?
    * [X] in the README.md
    * [X] in the code as JavaDoc comments
* ~~[ ] Is the new functionality tested by unit test?~~
    * It is hard to test this functionality in CI.
    * We manually tested that this works well.
    * Please also consider using [junit-quickcheck](https://github.com/pholser/junit-quickcheck) for property-based testing if possible.

## Other Notes (if exists)

* Other important information
