### PR TITLE
Implement STLInputAtomic constructAPs

### DIFF
--- a/core/src/main/java/net/maswag/falcaun/STLInputAtomic.java
+++ b/core/src/main/java/net/maswag/falcaun/STLInputAtomic.java
@@ -10,7 +10,6 @@ import java.util.*;
 public class STLInputAtomic extends STLAbstractAtomic {
     private final List<List<Character>> abstractInputs = new ArrayList<>();
     private final List<List<Double>> concreteInputs = new ArrayList<>();
-    private final List<Character> largest = Collections.emptyList();
     private List<Map<Character, Double>> inputMapper;
 
     /**
@@ -30,13 +29,70 @@ public class STLInputAtomic extends STLAbstractAtomic {
      */
     @Override
     public Set<String> getAllAPs() {
-        return getAllAPs(abstractInputs, largest);
+        return super.getAllAPs(abstractInputs.size());
     }
 
     @Override
     public void constructSatisfyingAtomicPropositions() {
         super.constructSatisfyingAtomicPropositions();
-        constructAtomicStrings(concreteInputs, abstractInputs, largest);
+        constructAtomicStrings(abstractInputs.size());
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    protected Set<Character> constructSmallerAPs(int index, double threshold) {
+        //Each element of concreateValues must be sorted in ascending order.
+        var concreteValues = concreteInputs;
+        var abstractValues = abstractInputs;
+
+        int bsResult = Collections.binarySearch(concreteValues.get(index), threshold);
+        int thresholdIndex = (bsResult >= 0) ? (bsResult - 1) : (~bsResult - 1);
+        Set<Character> resultAPs = new HashSet<>(abstractValues.get(index).subList(0, thresholdIndex + 1));
+
+        return resultAPs;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    protected Set<Character> constructLargerAPs(int index, double threshold) {
+        var concreteValues = concreteInputs;
+        var abstractValues = abstractInputs;
+
+        int bsResult = Collections.binarySearch(concreteValues.get(index), threshold);
+        int thresholdIndex = (bsResult >= 0) ? (bsResult + 1) : (~bsResult);
+        Set<Character> resultAPs = new HashSet<>(abstractValues.get(index).subList(thresholdIndex, abstractValues.get(index).size()));
+
+        return resultAPs;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    protected Set<Character> constructEqAPs(int index, double threshold) {
+        var concreteValues = concreteInputs;
+        var abstractValues = abstractInputs;
+
+        int bsResult = Collections.binarySearch(concreteValues.get(index), threshold);
+        if (bsResult < 0) {
+            var errMsg = String.format("%d-th input signal equals to %f does not exist.", index, threshold);
+            throw new RuntimeException(errMsg);
+        }
+        return Set.of(abstractValues.get(index).get(bsResult));
+    }
+
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    protected Set<Character> constructAllAPs(int index) {
+        var abstractValues = abstractInputs;
+        return new HashSet<>(abstractValues.get(index));
     }
 
     private void setInputMaps() {

--- a/core/src/test/java/net/maswag/falcaun/STLAtomicTest.java
+++ b/core/src/test/java/net/maswag/falcaun/STLAtomicTest.java
@@ -198,4 +198,42 @@ class STLAtomicTest {
             assertThrows(RuntimeException.class, () -> formula.toAbstractString());
         }
     }
+
+    @Test
+    void toAbstractStringOutputPositive() {
+        List<Map<Character, Double>> outputMapper = new ArrayList<>();
+        List<Character> largest = List.of('c', 'x', 'y');
+        outputMapper.add(Map.of('a', 1.0, 'b', 2.0));
+        outputMapper.add(Map.of());
+        outputMapper.add(Map.of());
+
+        List<Pair<STLOutputAtomic, Set<String>>> testCases = List.of(
+            Pair.of(new STLOutputAtomic(0, STLOutputAtomic.Operation.lt, 0.5), Set.of()),
+            Pair.of(new STLOutputAtomic(0, STLOutputAtomic.Operation.lt, 1.0), Set.of("axy")),
+            Pair.of(new STLOutputAtomic(0, STLOutputAtomic.Operation.lt, 1.5), Set.of("axy")),
+            Pair.of(new STLOutputAtomic(0, STLOutputAtomic.Operation.lt, 2.0), Set.of("axy", "bxy")),
+            Pair.of(new STLOutputAtomic(0, STLOutputAtomic.Operation.lt, 2.5), Set.of("axy", "bxy", "cxy")),
+            Pair.of(new STLOutputAtomic(0, STLOutputAtomic.Operation.gt, 0.5), Set.of("axy", "bxy", "cxy")),
+            Pair.of(new STLOutputAtomic(0, STLOutputAtomic.Operation.gt, 1.0), Set.of("bxy", "cxy")),
+            Pair.of(new STLOutputAtomic(0, STLOutputAtomic.Operation.gt, 1.5), Set.of("bxy", "cxy")),
+            Pair.of(new STLOutputAtomic(0, STLOutputAtomic.Operation.gt, 2.0), Set.of("cxy")),
+            Pair.of(new STLOutputAtomic(0, STLOutputAtomic.Operation.gt, 2.5), Set.of("cxy")),
+            Pair.of(new STLOutputAtomic(0, STLOutputAtomic.Operation.eq, 0.5), Set.of("axy")),
+            Pair.of(new STLOutputAtomic(0, STLOutputAtomic.Operation.eq, 1.0), Set.of("axy")),
+            //Pair.of(new STLOutputAtomic(0, STLOutputAtomic.Operation.eq, 1.5), Set.of("bxy", "cxy")),
+            Pair.of(new STLOutputAtomic(0, STLOutputAtomic.Operation.eq, 2.0), Set.of("bxy"))
+            //Pair.of(new STLOutputAtomic(0, STLOutputAtomic.Operation.eq, 2.5), Set.of("cxy"))
+        );
+
+        for (Pair<STLOutputAtomic, Set<String>> test : testCases) {
+            var formula = test.getLeft();
+            formula.setAtomic(outputMapper, largest);
+
+            // We do an ad hoc parsing of the abstract string to get the atomic propositions
+            var actual = Arrays.stream(formula.toAbstractString()
+                    .split("\"")).filter(s -> s.length() == outputMapper.size()).collect(Collectors.toSet());
+            var expected = test.getRight();
+            assertEquals(expected, actual);
+        }
+    }
 }


### PR DESCRIPTION
## Summary of the changes
InputMapper and OutputMapper shared an algorithm for constructing Atomic Propositions. But it had problems caused by the below reasons.

* Input values are the points, and Output values are the ranges.
  * For example, given output value `['a':0, 'b':1]`, 'a' represents _(-Inf,_ 0], and 'b' represents (0, 1]. (the largest represents (1, Inf])

* OutputMapper has a signal `largest`, representing a value the larger than the final output value.
  On the other hand, `largest` for InputMapper is not given.

This PR splits the method for constructing APs for InputMapper and OutputMapper and implement each.
* The behaviour of OutputMapper is unchanged
* You can show the behavior of InputMapper in `STLAtomicTest.java`

## Check list

* [ ] Are the contributors appropriately acknowledged?
    * [ ] in the README.md
    * [ ] in the code as JavaDoc comments
* [ ] Is the corresponding paper listed in the README.md (if exists)?
* [ ] Is the new functionality tested by unit test?
    * Please also consider using [junit-quickcheck](https://github.com/pholser/junit-quickcheck) for property-based testing if possible.
