### PR TITLE
Simulink Model Implementation using python

### DIFF
--- a/example/kotlin/ATS1-python.kts
+++ b/example/kotlin/ATS1-python.kts
@@ -1,0 +1,104 @@
+#!/usr/bin/env kscript
+
+var signalStep = 1.0
+val initScript = "./autotrans_matlab.py"
+
+// This script depends on FalCAuN-core and FalCAuN-python
+@file:DependsOn("net.maswag.falcaun:FalCAuN-core:1.0-SNAPSHOT", "net.maswag.falcaun:FalCAuN-python:1.0-SNAPSHOT")
+// And requires JEP library
+// Below is an example path to the JEP library when using pyenv and python 3.10.15
+//@file:KotlinOptions("-Djava.library.path=$PYENV_ROOT/versions/3.10.15/lib/python3.10/site-packages/jep")
+
+import ch.qos.logback.classic.Level
+import ch.qos.logback.classic.Logger
+import net.automatalib.modelchecker.ltsmin.AbstractLTSmin
+import net.automatalib.modelchecker.ltsmin.LTSminVersion
+import net.maswag.falcaun.*
+import org.slf4j.LoggerFactory
+import kotlin.streams.toList
+
+// The following surprises the debug log
+var updaterLogger = LoggerFactory.getLogger(AbstractAdaptiveSTLUpdater::class.java) as Logger
+updaterLogger.level = Level.INFO
+var updateListLogger = LoggerFactory.getLogger(AdaptiveSTLList::class.java) as Logger
+updateListLogger.level = Level.INFO
+var LTSminVersionLogger = LoggerFactory.getLogger(LTSminVersion::class.java) as Logger
+LTSminVersionLogger.level = Level.INFO
+var AbstractLTSminLogger = LoggerFactory.getLogger(AbstractLTSmin::class.java) as Logger
+AbstractLTSminLogger.level = Level.INFO
+var EQSearchProblemLogger = LoggerFactory.getLogger(EQSearchProblem::class.java) as Logger
+EQSearchProblemLogger.level = Level.INFO
+var SimulinkSteadyStateGeneticAlgorithmLogger = LoggerFactory.getLogger(EQSteadyStateGeneticAlgorithm::class.java) as Logger
+SimulinkSteadyStateGeneticAlgorithmLogger.level = Level.INFO
+
+// Define the input and output mappers
+val throttleValues = listOf(0.0, 100.0)
+val brakeValues = listOf(0.0, 325.0)
+val inputMapper = InputMapperReader.make(listOf(throttleValues, brakeValues))
+val velocityValues = listOf(20.0, 40.0, 60.0, 80.0, 100.0, 120.0, null)
+val accelerationValues = listOf(null)
+val gearValues = listOf(null)
+val outputMapperReader = OutputMapperReader(listOf(velocityValues, accelerationValues, gearValues))
+outputMapperReader.parse()
+val signalMapper = ExtendedSignalMapper()
+val mapper =
+    NumericSULMapper(inputMapper, outputMapperReader.largest, outputMapperReader.outputMapper, signalMapper)
+
+// Define the STL properties
+val stlFactory = STLFactory()
+val stlList = listOf(
+    "[] (signal(0) < 120)",
+    "[] (signal(0) < 100)",
+    "[] (signal(0) < 80)",
+    "[] (signal(0) < 60)",
+    "[] (signal(0) < 40)",
+    "[] (signal(0) < 20)"
+).stream().map { stlString ->
+    stlFactory.parse(
+        stlString,
+        inputMapper,
+        outputMapperReader.outputMapper,
+        outputMapperReader.largest
+    )
+}.toList()
+val signalLength = 30
+val properties = AdaptiveSTLList(stlList, signalLength)
+
+// Constants for the GA-based equivalence testing
+val maxTest = 50000
+val populationSize = 200
+val crossoverProb = 0.5
+val mutationProb = 0.01
+
+// Load the automatic transmission model. This automatically closes MATLAB
+PythonContinuousNumericSUL(initScript, signalStep).use { autoTransSUL ->
+    // Configure and run the verifier
+    val verifier = NumericSULVerifier(autoTransSUL, signalStep, properties, mapper)
+    // Timeout must be set before adding equivalence testing
+    verifier.setTimeout(5 * 60 * 8) // 5 minutes
+    verifier.addCornerCaseEQOracle(signalLength, signalLength / 2);
+    verifier.addGAEQOracleAll(
+        signalLength,
+        maxTest,
+        ArgParser.GASelectionKind.Tournament,
+        populationSize,
+        crossoverProb,
+        mutationProb
+    )
+    val result = verifier.run()
+
+    // Print the result
+    if (result) {
+        println("The property is likely satisfied")
+    } else {
+        for (i in 0 until verifier.cexProperty.size) {
+            println("${verifier.cexProperty[i]} is falsified by the following counterexample")
+            println("cex concrete input: ${verifier.cexConcreteInput[i]}")
+            println("cex abstract input: ${verifier.cexAbstractInput[i]}")
+            println("cex output: ${verifier.cexOutput[i]}")
+        }
+    }
+    println("Execution time for simulation: ${verifier.simulationTimeSecond} [sec]")
+    println("Number of simulations: ${verifier.simulinkCount}")
+    println("Number of simulations for equivalence testing: ${verifier.simulinkCountForEqTest}")
+}

--- a/example/kotlin/ATS1-python.kts
+++ b/example/kotlin/ATS1-python.kts
@@ -53,14 +53,14 @@ val stlList = listOf(
     "[] (signal(0) < 60)",
     "[] (signal(0) < 40)",
     "[] (signal(0) < 20)"
-).stream().map { stlString ->
+).map { stlString ->
     stlFactory.parse(
         stlString,
         inputMapper,
         outputMapperReader.outputMapper,
         outputMapperReader.largest
     )
-}.toList()
+}
 val signalLength = 30
 val properties = AdaptiveSTLList(stlList, signalLength)
 

--- a/example/kotlin/ATS1-python.kts
+++ b/example/kotlin/ATS1-python.kts
@@ -75,7 +75,7 @@ PythonContinuousNumericSUL(initScript, signalStep).use { autoTransSUL ->
     // Configure and run the verifier
     val verifier = NumericSULVerifier(autoTransSUL, signalStep, properties, mapper)
     // Timeout must be set before adding equivalence testing
-    verifier.setTimeout(5 * 60 * 8) // 5 minutes
+    verifier.setTimeout(60 * 40) // 40 minutes
     verifier.addCornerCaseEQOracle(signalLength, signalLength / 2);
     verifier.addGAEQOracleAll(
         signalLength,

--- a/example/kotlin/autotrans_matlab.py
+++ b/example/kotlin/autotrans_matlab.py
@@ -1,6 +1,7 @@
 import sys
 sys.path.append(".")
 
+import os
 from abstract_sul import AbstractSUL
 from typing import List, Callable, Tuple
 #from java.util import ArrayList
@@ -86,12 +87,12 @@ class SimulinkModel:
         self.reset()
 
     def step(self, inputSignal : List[float]) -> Tuple[List[float], List[List[float]]]:
-        assert (self.isInitial or not inputSignal == [])
+        assert self.isInitial or not inputSignal
         self.inputSignal.add(inputSignal)
         return self.exec_aux()
 
     def exec(self, inputSignals: List[List[float]]) -> Tuple[List[float], List[List[float]]]:
-        assert (self.isInitial or not inputSignals == [])
+        assert self.isInitial or not inputSignals
 
         for e in inputSignals:
             self.inputSignal.add(e)
@@ -162,7 +163,7 @@ class SimulinkModel:
 
         # Enable fast restart
         if self.useFastRestart:
-            # on を off へ書き換え
+            # Switch FastRestart on
             eng.set_param(mdl,'FastRestart','on', nargout=0)
         else:
             eng.set_param(mdl,'FastRestart','off', nargout=0)
@@ -277,7 +278,7 @@ class SUL(AbstractSUL):
         versionString = eng.version('-release')
         oldpath = eng.path()
         userpath = eng.userpath()
-        arg0 = userpath + "/Examples/" + versionString + "/simulink_automotive/ModelingAnAutomaticTransmissionControllerExample/"
+        arg0 = os.path.join(userpath, "Examples", versionString, "simulink_automotive", "ModelingAnAutomaticTransmissionControllerExample")
         eng.path(arg0, oldpath)
 
         eng.load_system(SUL.MDL, nargout=0)

--- a/example/kotlin/autotrans_matlab.py
+++ b/example/kotlin/autotrans_matlab.py
@@ -1,0 +1,337 @@
+import sys
+sys.path.append(".")
+
+from abstract_sul import AbstractSUL
+from typing import List, Callable, Tuple
+#from java.util import ArrayList
+import matlab.engine
+import matlab
+import numpy as np
+
+signalStep=0.00025
+
+class Signal:
+    """
+    Equivalent to Signal
+    """
+
+    timestamps : List[float]
+    signalValue : List[List[float]]
+    timeStep : float
+    def __init__(self, timeStep):
+        self.timeStep = timeStep
+        self.timestamps = []
+        self.signalValue = []
+
+    def getTimestamps(self) -> List[float]:
+        return self.timestamps
+
+    def duration(self) -> float:
+        return 0.0 if len(self.timestamps) == 0 else self.timestamps[-1]
+    
+    def add(self, inputValue : List[float]) -> None:
+        if len(self.timestamps) == 0:
+            self.timestamps.append(0.0)
+        else:
+            self.timestamps.append(self.duration() + self.timeStep)
+        self.signalValue.append(inputValue)
+
+    def dimension(self) -> int:
+        if len(self.signalValue) == 0:
+            return 0
+        else:
+            return len(self.signalValue[0])
+    
+    def dimensionGet(self, index) -> List[float]:
+        return [s[index] for s in self.signalValue]
+
+
+
+class SimulinkModel:
+    """
+    Compatible implementation of SimulinkModel
+    """
+
+    mdl : str
+    paramNames : List[str]
+    signalStep : float
+    simulinkSimulationStep : float
+    inputSignal : Signal
+
+    eng : matlab.engine.MatlabEngine
+    isInitial : bool
+    counter : int
+    useFastRestart = True
+    def __init__(
+        self,
+        initScript: Callable[[matlab.engine.MatlabEngine], None],
+        mdl: str,
+        paramNames: List[str],
+        signalStep: float,
+        simulinkSimulationStep: float
+    ) -> None:
+        self.mdl = mdl
+        self.paramNames = paramNames
+        self.signalStep = signalStep
+        self.simulinkSimulationStep = simulinkSimulationStep
+        self.counter = 0
+
+        engines = matlab.engine.find_matlab()
+        self.eng = matlab.engine.start_matlab() if len(engines) == 0 else matlab.engine.connect_matlab()
+
+        self.eng.clear(nargout=0)
+        self.eng.warning('off', 'Simulink:LoadSave:EncodingMismatch')
+        self.eng.workspace["signalStep"] = signalStep
+
+        initScript(self.eng)
+
+        self.reset()
+
+    def step(self, inputSignal : List[float]) -> Tuple[List[float], List[List[float]]]:
+        assert (self.isInitial or not inputSignal == [])
+        self.inputSignal.add(inputSignal)
+        return self.exec_aux()
+
+    def exec(self, inputSignals: List[List[float]]) -> Tuple[List[float], List[List[float]]]:
+        assert (self.isInitial or not inputSignals == [])
+
+        for e in inputSignals:
+            self.inputSignal.add(e)
+
+        return self.exec_aux()
+
+    def exec_aux(self):
+        # For efficiency, we use StringBuilder to make the entire script to execute in MATLAB rather than evaluate each line.
+
+        # Make the input signal
+        self.make_dataset()
+        self.configureSimulink()
+        self.preventHugeTempFile()
+
+        # Execute the simulation
+        self.eng.set_param(self.mdl,'SaveFinalState','on','FinalStateName', 'myOperPoint','SaveCompleteFinalSimState','on', nargout=0)
+        if self.isInitial:
+            self.eng.set_param(self.mdl, 'LoadInitialState', 'off', nargout=0)
+            self.isInitial = False
+        else:
+            self.eng.set_param(self.mdl, 'LoadInitialState', 'on', nargout=0)
+            self.eng.set_param(self.mdl, 'InitialState', 'myOperPoint', nargout=0)
+        
+
+        # Run the simulation
+        self.runSimulation(self.inputSignal.duration())
+
+        # get the simulation result and make the result
+        y = self.getResult()
+        t = self.getTimestamps()
+        assert(len(t) == len(y))
+
+        # Final internal process
+        assert not self.isInitial
+
+        return (t, y)
+
+    def reset(self) -> None:
+        self.inputSignal = Signal(self.signalStep)
+        self.isInitial = True
+        self.counter += 1
+
+    def close(self) -> None:
+        self.eng.close()
+    
+    def make_dataset(self) -> None:
+        eng = self.eng
+        timeVector = matlab.double(self.inputSignal.getTimestamps())
+        ds = eng.Simulink.SimulationData.Dataset()
+        for i in range(0, self.inputSignal.dimension()):
+            tmp = matlab.double(self.inputSignal.dimensionGet(i))
+            input = eng.timeseries(tmp, timeVector)
+
+            #eng.setfield(eng.getfield(input, "DataInfo"), "Interpolation", eng.tsdata.interpolation('zoh'))
+            
+            # Assume InterpolationMethod is LINEAR
+            eng.setfield(eng.getfield(input, "DataInfo"), "Interpolation", eng.tsdata.interpolation('linear'))
+            
+            ds = eng.addElement(ds, input, self.paramNames[i])
+        eng.workspace["ds"] = ds
+
+    def configureSimulink(self) -> None:
+        eng = self.eng
+        mdl = self.mdl
+        # We use the data in ds
+        eng.set_param(mdl, 'LoadExternalInput', 'on', nargout=0)
+        eng.set_param(mdl, 'ExternalInput', 'ds', nargout=0)
+
+        # Enable fast restart
+        if self.useFastRestart:
+            # on を off へ書き換え
+            eng.set_param(mdl,'FastRestart','on', nargout=0)
+        else:
+            eng.set_param(mdl,'FastRestart','off', nargout=0)
+
+        ## Configuration on the accelerator
+        # Use normal mode
+        # eng.set_param(mdl,'SimulationMode','normal', nargout=0)
+        # Enable accelerator mode
+        eng.set_param(mdl,'SimulationMode','accelerator', nargout=0)
+        # Enable classic accelerator mode
+        eng.set_param(0, 'GlobalUseClassicAccelMode', 'on', nargout=0)
+
+
+        # The save format must be an array
+        eng.set_param(mdl, 'SaveFormat', 'Array', nargout=0)
+        # We save the output as yout
+        eng.set_param(mdl, 'SaveOutput', 'on', nargout=0)
+        eng.set_param(mdl, 'OutputSaveName', 'yout', nargout=0)
+        # We save the time as tout
+        eng.set_param(mdl, 'SaveTime', 'on', nargout=0)
+        eng.set_param(mdl, 'TimeSaveName', 'tout', nargout=0)
+
+        # Configuration on the decimation
+        eng.set_param(mdl, 'SolverType', 'Fixed-step', nargout=0)
+        eng.set_param(mdl, 'FixedStep', str(self.simulinkSimulationStep), nargout=0)
+        # We dump all the results
+        eng.set_param(mdl, 'LimitDataPoints', 'off', nargout=0)
+        # We do not decimate the result
+        # eng.set_param(mdl, 'Decimation', signalStep / simulinkSimulationStep, nargout=0)
+
+    
+    def preventHugeTempFile(self) -> None:
+        eng = self.eng
+        eng.Simulink.sdi.setAutoArchiveMode(False, nargout=0)
+        eng.Simulink.sdi.setArchiveRunLimit(0, nargout=0)
+        eng.Simulink.sdi.clear(nargout=0)
+
+    def runSimulation(self, stopTime : float) -> None:
+        eng = self.eng
+
+        # append the input signal
+        eng.workspace["in"] = eng.Simulink.SimulationInput(self.mdl)
+        eng.workspace["in"] = eng.eval("in.setExternalInput(ds)")
+
+        # Set the StopTime
+        eng.workspace["in"] = eng.eval("in.setModelParameter('StopTime', '{}')".format(stopTime))
+        # Save the output to yout
+        if not self.useFastRestart:
+            eng.workspace["in"] = eng.eval("in.setModelParameter('SaveOutput', 'on')")
+            eng.workspace["in"] = eng.eval("in.setModelParameter('OutputSaveName', 'yout')")
+            eng.workspace["in"] = eng.eval("in.setModelParameter('SaveTime', 'on')")
+            eng.workspace["in"] = eng.eval("in.setModelParameter('TimeSaveName', 'tout')")
+
+        eng.workspace["in"] = eng.eval("in.setModelParameter('LoadInitialState', 'off')")
+
+        # Execute the simulation
+        eng.workspace["simOut"] = eng.sim(eng.workspace["in"])
+        
+        # We handle the output as double.
+        eng.workspace["y"] = eng.eval("double(simOut.get('yout'))")
+        eng.workspace["t"] = eng.eval("double(simOut.get('tout'))")
+    
+    
+    def getResult(self) -> List[List[float]]:
+        eng = self.eng
+        ySize = eng.size(eng.workspace["y"])[0]
+        
+        if self.inputSignal.duration() == 0.0:
+            tmpY = []
+            if ySize[1] == 1.0 :
+                # When the output is one dimensional, we need to convert it to 1D array first.
+                tmp : float = eng.workspace["y"]
+                tmpY = [tmp]
+            else:
+                tmpY = eng.workspace["y"]
+
+            if tmpY == []:
+                # The simulation output is null
+                y = []
+            else:
+                y = [tmpY]
+
+        else:
+            if ySize[1] == 1.0:
+                # When the output is one dimensional, we need to convert it to 2D array.
+                tmpY = eng.workspace["y"]
+                y = [[d] for d in tmpY]
+            else:
+                y = eng.workspace["y"]
+        
+        return y
+
+    def getTimestamps(self) -> List[float]:
+        if self.inputSignal.duration() == 0.0 :
+            return [0.0]
+        else:
+            return self.eng.workspace["t"]
+
+class SUL(AbstractSUL):
+    """
+    Python wrapped SUL using the Autotrans_shift Simulink model
+    """
+
+    simulinkModel : SimulinkModel
+    MDL = "Autotrans_shift"
+
+    def initScript(eng : matlab.engine.MatlabEngine) -> None:
+        """
+        Compatible to `initScript` in AutoTrans.kt
+        """
+
+        versionString = eng.version('-release')
+        oldpath = eng.path()
+        userpath = eng.userpath()
+        arg0 = userpath + "/Examples/" + versionString + "/simulink_automotive/ModelingAnAutomaticTransmissionControllerExample/"
+        eng.path(arg0, oldpath)
+
+        eng.load_system(SUL.MDL, nargout=0)
+
+    def __init__(self):
+        paramNames = ["throttle", "brake"]
+        signalStep = 1.0
+        simulinkSimulationStep = 0.0025
+        self.simulinkModel = SimulinkModel(SUL.initScript, SUL.MDL, paramNames, signalStep, simulinkSimulationStep)
+
+    def step(self, inputSignal : List[float]) -> List[List[float]]:
+        """
+        Returns an array 'ary' : ary[i][0] is the time, and ary[i][1:] is the output signal.
+        """
+
+        (t, y) = self.simulinkModel.step(inputSignal)
+        y = np.array(y[0], dtype=np.float64)
+        t = np.array(t, dtype=np.float64)
+
+        ary = []
+        for i in range(len(y)):
+            a = np.insert(y[i], 0, t[i])
+            ary.append(list(a))
+
+        ret = np.array(ary, dtype=np.float64)
+        return ret.tolist()
+
+    def exec(self, inputSignals: List[List[float]]) -> np.ndarray:
+        (t, y) = self.simulinkModel.exec(inputSignals)
+        y = np.array(y[0], dtype=np.float64)
+        t = np.array(t, dtype=np.float64)
+
+        # Convert the result to numpy array
+        ary = []
+        for i in range(len(y)):
+            a = np.insert(y[i], 0, t[i])
+            ary.append(list(a))
+
+        ret = np.array(ary, dtype=np.float64)
+        return ret.tolist()
+    
+    def pre(self) -> None:
+        self.simulinkModel.reset()
+
+    def post(self) -> None:
+        self.simulinkModel.reset()
+
+    def close(self) -> None:
+        self.simulinkModel.close()
+
+#if __name__ == "__main__":
+#    sul = SUL()
+#    sul.step([0.0, 0.0])
+#    sul.close()
+#    print("terminated main")

--- a/example/kotlin/autotrans_matlab.py
+++ b/example/kotlin/autotrans_matlab.py
@@ -4,7 +4,6 @@ sys.path.append(".")
 import os
 from abstract_sul import AbstractSUL
 from typing import List, Callable, Tuple
-#from java.util import ArrayList
 import matlab.engine
 import matlab
 import numpy as np
@@ -328,9 +327,3 @@ class SUL(AbstractSUL):
 
     def close(self) -> None:
         self.simulinkModel.close()
-
-#if __name__ == "__main__":
-#    sul = SUL()
-#    sul.step([0.0, 0.0])
-#    sul.close()
-#    print("terminated main")

--- a/example/kotlin/autotrans_matlab.py
+++ b/example/kotlin/autotrans_matlab.py
@@ -8,8 +8,6 @@ import matlab.engine
 import matlab
 import numpy as np
 
-signalStep=0.00025
-
 class Signal:
     """
     Equivalent to Signal

--- a/example/kotlin/autotrans_matlab.py
+++ b/example/kotlin/autotrans_matlab.py
@@ -305,7 +305,7 @@ class SUL(AbstractSUL):
         ret = np.array(ary, dtype=np.float64)
         return ret.tolist()
 
-    def exec(self, inputSignals: List[List[float]]) -> np.ndarray:
+    def exec(self, inputSignals: List[List[float]]) -> List[List[float]]:
         (t, y) = self.simulinkModel.exec(inputSignals)
         y = np.array(y[0], dtype=np.float64)
         t = np.array(t, dtype=np.float64)

--- a/python/src/main/java/net/maswag/falcaun/PythonContinuousNumericSUL.java
+++ b/python/src/main/java/net/maswag/falcaun/PythonContinuousNumericSUL.java
@@ -99,11 +99,6 @@ public class PythonContinuousNumericSUL implements ContinuousNumericSUL, Closeab
 
         var length1 = data.size();
         var length2 = data.get(0).size();
-        if (length2 != this.inputSignal.get(0).size() + 1) { // +1 for the timestamp
-            throw new IllegalStateException("Unexpected shape: The length of the second dimension " +
-                "of the array returned by JEP (" + length2 + ") does not match expected size (" +
-                (this.inputSignal.get(0).size() + 1) + ").");
-        }
 
         var timestamps = new ArrayList<Double>();
         var result = new ArrayList<List<Double>>();

--- a/python/src/main/java/net/maswag/falcaun/PythonContinuousNumericSUL.java
+++ b/python/src/main/java/net/maswag/falcaun/PythonContinuousNumericSUL.java
@@ -98,7 +98,13 @@ public class PythonContinuousNumericSUL implements ContinuousNumericSUL, Closeab
             }).collect(Collectors.toList());
 
         var length1 = data.size();
+        if (length1 == 0) {
+            throw new IllegalArgumentException("Input data is empty.");
+        }
         var length2 = data.get(0).size();
+        if (length2 < 2) {
+            throw new IllegalArgumentException("Each row must contain at least a timestamp and one output value.");
+        }
 
         var timestamps = new ArrayList<Double>();
         var result = new ArrayList<List<Double>>();

--- a/python/src/main/java/net/maswag/falcaun/PythonContinuousNumericSUL.java
+++ b/python/src/main/java/net/maswag/falcaun/PythonContinuousNumericSUL.java
@@ -161,9 +161,16 @@ public class PythonContinuousNumericSUL implements ContinuousNumericSUL, Closeab
         ArrayList<?> ret = null;
 
         try {
-            for (var e : inputSignal) {
-                this.inputSignal.add(e);
-                ret = this.model.step(e);
+            // Use exec() if it is available in the model for batch processing.
+            // Otherwise, use step() for each input signal.
+            if (this.model.hasExec()) {
+                this.inputSignal.addAll(inputSignal);
+                ret = this.model.exec(inputSignal.asList());
+            } else {
+                for (var e : inputSignal) {
+                    this.inputSignal.add(e);
+                    ret = this.model.step(e);
+                }
             }
         } catch (JepException exc) {
             throw new ExecutionException(exc);

--- a/python/src/main/java/net/maswag/falcaun/PythonNumericSUL.java
+++ b/python/src/main/java/net/maswag/falcaun/PythonNumericSUL.java
@@ -106,20 +106,19 @@ public class PythonNumericSUL implements NumericSUL, Closeable {
         pre();
 
         ArrayList<List<Double>> outputs = new ArrayList<List<Double>>();
-        ArrayList<?> ret = null;
 
         try {
             // Use exec() if it is available in the model for batch processing.
             // Otherwise, use step() for each input signal.
             if (this.model.hasExec()) {
-                ret = this.model.exec(inputSignal.asList());
+                ArrayList<?> ret = this.model.exec(inputSignal.asList());
                 outputs = ret.stream().map(e1 -> {
                     Stream<?> s = List.class.cast(e1).stream();
                     return s.map(e2 -> Double.class.cast(e2)).collect(Collectors.toList());
                 }).collect(Collectors.toCollection(ArrayList::new));
             } else {
                 for (var e : inputSignal) {
-                    ret = this.model.step(e);
+                    ArrayList<?> ret = this.model.step(e);
                     var output = ret.stream().map(obj -> Double.class.cast(obj)).collect(Collectors.toList());
                     outputs.add(output);
                 }

--- a/python/src/test/java/net/maswag/falcaun/PythonNumericSULTest.java
+++ b/python/src/test/java/net/maswag/falcaun/PythonNumericSULTest.java
@@ -15,6 +15,7 @@ class PythonNumericSULTest {
     // The first output is truncated to 100.0 if it exceeds 100.0.
     // The second output is the sum modulo 100.0.
     static final String numericScript = "./src/test/resources/test_numeric_sul.py";
+    static final String numericScriptWithExec = "./src/test/resources/test_numeric_sul_with_exec.py";
 
     @Test
     void numericStepTest() throws Exception {
@@ -42,6 +43,33 @@ class PythonNumericSULTest {
     @Test
     void numericExecuteTest() throws Exception {
         try (var sul = new PythonNumericSUL(numericScript)) {
+            sul.pre();
+
+            var inputSeq = java.util.List.of(
+                java.util.Arrays.asList(10.0, 0.5),
+                java.util.Arrays.asList(20.0, 0.5),
+                java.util.Arrays.asList(50.0, 0.5),
+                java.util.Arrays.asList(80.0, 0.5),
+                java.util.Arrays.asList(-20.0, 0.5)
+            );
+            var word = net.automatalib.word.Word.fromList(inputSeq);
+            var ioSignal = sul.execute(word);
+            var outputs = ioSignal.getOutputSignal();
+            assertEquals(5, outputs.size());
+            assertIterableEquals(java.util.Arrays.asList(10.5, 10.5), outputs.getSymbol(0));
+            assertIterableEquals(java.util.Arrays.asList(31.0, 31.0), outputs.getSymbol(1));
+            assertIterableEquals(java.util.Arrays.asList(81.5, 81.5), outputs.getSymbol(2));
+            assertIterableEquals(java.util.Arrays.asList(100.0, 62.0), outputs.getSymbol(3));
+            assertIterableEquals(java.util.Arrays.asList(80.5, 42.5), outputs.getSymbol(4));
+
+            sul.post();
+        }
+    }
+
+    @Test
+    void numericExecuteTest2() throws Exception {
+        // Same results as numericExecuteTest, but using exec function in python.
+        try (var sul = new PythonNumericSUL(numericScriptWithExec)) {
             sul.pre();
 
             var inputSeq = java.util.List.of(

--- a/python/src/test/resources/test_numeric_sul_with_exec.py
+++ b/python/src/test/resources/test_numeric_sul_with_exec.py
@@ -1,0 +1,32 @@
+from typing import List
+
+class SUL:
+    def __init__(self):
+        self.state = (0.0, 0.0)
+
+    def step(self, inputSignal: List[float]) -> List[float]:
+        """
+        The first output is truncated to 100.0 if it exceeds 100.0.
+        The second output is the sum modulo 100.0.
+        """
+
+        [sum0, sum1] = self.state
+        sum0 = sum0 + sum(inputSignal)
+        sum0 = max(0.0, min(100.0, sum0))
+        sum1 = (sum1 + sum(inputSignal)) % 100.0
+        self.state = [sum0, sum1]
+        return self.state
+    
+    def exec(self, inputSignals: List[List[float]]) -> List[List[float]]:
+        ret = []
+        for e in inputSignals:
+            ret.append(self.step(e))
+        return ret
+
+    def pre(self):
+        self.state = (0.0, 0.0)
+        
+    def post(self):
+        pass
+    def close(self):
+        pass


### PR DESCRIPTION
## Summary of the changes
It depends on #268 
* Add autotrans_python.py
  * A AutoTrans SUL Model implemented by python
  * It uses python-binding simulink
* Add ATS1-python.kts
  * A compatible to ATS1.main.kts
  * It calls autotrans_python.py using FalCAuN-python
* Add a feature to optimize to run PythonNumericSUL.exec
  * When the given python SUL implements `exec` interface, PythonNumericSUL uses it

https://github.com/taiseiKMC/FalCAuN/compare/hsaito/jep-demo..hsaito/python-wrapped-matlab

## Check list

* [x] Are the contributors appropriately acknowledged?
    * [x] in the README.md
    * [x] in the code as JavaDoc comments
* [x] Is the corresponding paper listed in the README.md (if exists)?
* [x] Is the new functionality tested by unit test?
    * Please also consider using [junit-quickcheck](https://github.com/pholser/junit-quickcheck) for property-based testing if possible.

## Other Notes (if exists)

* Other important information
