### PR TITLE
Configure JEP for CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,6 +19,16 @@ jobs:
             sudo apt-get update && sudo apt-get install openjdk-17-jdk maven -y
             sudo update-alternatives --set java /usr/lib/jvm/java-17-openjdk-amd64/bin/java
             sudo update-alternatives --set javac /usr/lib/jvm/java-17-openjdk-amd64/bin/javac
+      - run:
+          name: Install Python and JEP
+          command: |
+            sudo apt-get update && sudo apt-get install -y python3 python3-pip python3-dev
+            pip3 install --upgrade setuptools wheel
+            pip3 install --no-cache-dir --no-build-isolation jep==4.2.1
+            python3 - <<'EOF' >> $BASH_ENV
+import site
+print("export LD_LIBRARY_PATH=" + site.getsitepackages()[0] + "/jep:$LD_LIBRARY_PATH")
+EOF
       - matlab/install:
           release: R2024a
           products: Simulink


### PR DESCRIPTION
## Summary
- add python and JEP installation steps for CircleCI

## Testing
- `mvn -pl core -DskipTests=false -Dtest=ArgParserTest test`

------
https://chatgpt.com/codex/tasks/task_e_686b1d906bec8332a03e9beb342b3a78