### PR TITLE
Fix NumericSULMapper constructor : Sort output entries by value

### DIFF
--- a/core/src/main/java/net/maswag/falcaun/NumericSULMapper.java
+++ b/core/src/main/java/net/maswag/falcaun/NumericSULMapper.java
@@ -66,18 +66,18 @@ public class NumericSULMapper implements SULMapper<String, String, List<Double>,
         concreteOutputs = new ArrayList<>();
 
         for (Map<Character, Double> entry : outputMapper) {
-            // Sort the entry by value and extract keys and values in sorted order
-            List<Map.Entry<Character, Double>> sortedEntries = entry.entrySet()
-                .stream()
-                .sorted(Map.Entry.comparingByValue())
-                .collect(Collectors.toList());
             ArrayList<Character> cList = new ArrayList<>();
             ArrayList<Double> dList = new ArrayList<>();
-            for (Map.Entry<Character, Double> e : sortedEntries) {
-                cList.add(e.getKey());
-                dList.add(e.getValue());
-            }
-            assert cList.size() == dList.size();
+
+            // Sort the entry by value and add keys and values to cList and dList in sorted order
+            entry.entrySet()
+                .stream()
+                .sorted(Map.Entry.comparingByValue())
+                .forEachOrdered(e -> {
+                    cList.add(e.getKey());
+                    dList.add(e.getValue());
+                });
+
             abstractOutputs.add(cList);
             concreteOutputs.add(dList);
         }

--- a/core/src/main/java/net/maswag/falcaun/NumericSULMapper.java
+++ b/core/src/main/java/net/maswag/falcaun/NumericSULMapper.java
@@ -66,8 +66,17 @@ public class NumericSULMapper implements SULMapper<String, String, List<Double>,
         concreteOutputs = new ArrayList<>();
 
         for (Map<Character, Double> entry : outputMapper) {
-            ArrayList<Character> cList = new ArrayList<>(entry.keySet());
-            ArrayList<Double> dList = new ArrayList<>(entry.values());
+            // Sort the entry by value and extract keys and values in sorted order
+            List<Map.Entry<Character, Double>> sortedEntries = entry.entrySet()
+                .stream()
+                .sorted(Map.Entry.comparingByValue())
+                .collect(Collectors.toList());
+            ArrayList<Character> cList = new ArrayList<>();
+            ArrayList<Double> dList = new ArrayList<>();
+            for (Map.Entry<Character, Double> e : sortedEntries) {
+                cList.add(e.getKey());
+                dList.add(e.getValue());
+            }
             assert cList.size() == dList.size();
             abstractOutputs.add(cList);
             concreteOutputs.add(dList);

--- a/core/src/test/java/net/maswag/falcaun/NumericSULMapperOutputTest.java
+++ b/core/src/test/java/net/maswag/falcaun/NumericSULMapperOutputTest.java
@@ -3,10 +3,7 @@ package net.maswag.falcaun;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-import net.maswag.falcaun.STLAbstractAtomic.Operation;
-
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 

--- a/core/src/test/java/net/maswag/falcaun/NumericSULMapperOutputTest.java
+++ b/core/src/test/java/net/maswag/falcaun/NumericSULMapperOutputTest.java
@@ -3,6 +3,8 @@ package net.maswag.falcaun;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import net.maswag.falcaun.STLAbstractAtomic.Operation;
+
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
@@ -20,10 +22,7 @@ class NumericSULMapperOutputTest {
     @BeforeEach
     void setUp() {
         inputMapper = List.of(Map.of('a', 1.0, 'b', 2.0));
-        Map<Character, Double> m = new HashMap<>();
-        m.put('a', 1.0);
-        m.put('b', 2.0);
-        outputMapper = List.of(m);
+        outputMapper = List.of(Map.of('a', 1.0, 'b', 2.0)); 
         largest = List.of('c');
         mapper = new NumericSULMapper(inputMapper, largest, outputMapper, new SimpleSignalMapper());
     }


### PR DESCRIPTION

## Link to the corresponding issue (if exists)
Fixes #270

## Summary of the changes
To fix #270, sort the entries in `outputMapper` Map by its values in the NumericSULMapper constructor