### PR TITLE
Fixed a bug in TemporalRelease

### DIFF
--- a/.github/workflows/junit.yml
+++ b/.github/workflows/junit.yml
@@ -57,7 +57,9 @@ jobs:
         run: mvn test --projects python
         env:
           # Path to the jep library `jep-4.2.1.jar`
-          LD_LIBRARY_PATH: "/opt/hostedtoolcache/Python/3.13.5/x64/lib/python3.13/site-packages/jep"
+          LD_LIBRARY_PATH: ${{ env.LD_LIBRARY_PATH }}:${{ env.Python3_ROOT_DIR }}/lib/python3.13/site-packages/jep
+          JEP_JAVA_LIBRARY_PATH: ${{ env.Python3_ROOT_DIR }}/lib/python3.13/site-packages/jep
+
 
       - name: Upload coverage reports to Codecov
         uses: codecov/codecov-action@v5.4.3

--- a/core/src/main/java/net/maswag/falcaun/TemporalRelease.java
+++ b/core/src/main/java/net/maswag/falcaun/TemporalRelease.java
@@ -34,19 +34,13 @@ public class TemporalRelease<I> extends AbstractTemporalLogic<I> {
     }
 
     public RoSI getRoSIRaw(IOSignal<I> signal) {
-        // The semantics of p U q is max_i (q_i && (p_0 && p_1 && ... && p_i)),
-        // where p_i is the RoSI of the left formula at the i-th prefix of the signal,
-        // and q_i is the RoSI of the right formula at the i-th prefix of the signal.
-        // Since p R q is equivalent to !((!p) U (!q)), the semantics of p R q is
-        // !(max_i (!q_i && (!p_0 && !p_1 && ... && !p_i)))
-        // = (min_i (q_i || (p_0 || p_1 || ... || p_i)))
-        RoSI result = new RoSI(Double.POSITIVE_INFINITY, Double.POSITIVE_INFINITY);
         // The semantics of the Release operator (p R q) is:
         // min_i (q_i || (p_0 || p_1 || ... || p_i)),
         // where p_i is the RoSI of the left formula at the i-th prefix of the signal,
         // and q_i is the RoSI of the right formula at the i-th prefix of the signal.
         // This follows from the equivalence: p R q ≡ !((!p) U (!q)).
         RoSI result = new RoSI(Double.POSITIVE_INFINITY, Double.POSITIVE_INFINITY);
+
         // Take the suffixes of signal in the longest-first order and compute their RoSI.
         List<RoSI> historyRoSIs = signal.suffixes(true).stream().map(this.left::getRoSI).toList();
         for (int i = 0; i < signal.length(); i++) {

--- a/core/src/main/java/net/maswag/falcaun/TemporalRelease.java
+++ b/core/src/main/java/net/maswag/falcaun/TemporalRelease.java
@@ -7,10 +7,11 @@ import java.util.Objects;
 import java.util.Set;
 
 /**
- * <p>STLRelease class.</p>
+ * <p>TemporalRelease class.</p>
+ * <p>This class implements the release operator in STL and LTL.</p>
  *
- * @author Masaki Waga {@literal <masakiwaga@gmail.com>}
  * @param <I> Type of the input at each step
+ * @author Masaki Waga {@literal <masakiwaga@gmail.com>}
  */
 @Getter
 public class TemporalRelease<I> extends AbstractTemporalLogic<I> {
@@ -29,17 +30,27 @@ public class TemporalRelease<I> extends AbstractTemporalLogic<I> {
      */
     @Override
     public RoSI getRoSI(IOSignal<I> signal) {
-        return getRoSIRaw(signal).assignMax(new RoSI(Double.NEGATIVE_INFINITY, Double.POSITIVE_INFINITY));
+        return getRoSIRaw(signal).assignMin(new RoSI(Double.NEGATIVE_INFINITY, Double.POSITIVE_INFINITY));
     }
 
     public RoSI getRoSIRaw(IOSignal<I> signal) {
-        RoSI result = new RoSI(Double.NEGATIVE_INFINITY, Double.NEGATIVE_INFINITY);
+        // The semantics of p U q is max_i (q_i && (p_0 && p_1 && ... && p_i)),
+        // where p_i is the RoSI of the left formula at the i-th prefix of the signal,
+        // and q_i is the RoSI of the right formula at the i-th prefix of the signal.
+        // Since p R q is equivalent to !((!p) U (!q)), the semantics of p R q is
+        // !(max_i (!q_i && (!p_0 && !p_1 && ... && !p_i)))
+        // = (min_i (q_i || (p_0 || p_1 || ... || p_i)))
+        RoSI result = new RoSI(Double.POSITIVE_INFINITY, Double.POSITIVE_INFINITY);
 
+        // Take the suffixes of signal in the longest-first order and compute their RoSI.
+        List<RoSI> historyRoSIs = signal.suffixes(true).stream().map(this.left::getRoSI).toList();
         for (int i = 0; i < signal.length(); i++) {
-            RoSI nextRoSI = this.right.getRoSI(signal.subWord(i));
-            RoSI globalRoSI = signal.prefixes(true).stream().sorted((left, right) ->
-                    right.length() - left.length()).limit(i + 1).map(this.left::getRoSI).filter(Objects::nonNull).reduce(nextRoSI, RoSI::max);
-            result.assignMin(globalRoSI);
+            // Compute q_i || (p_0 || p_1 || ... || p_i)
+            RoSI releasedRoSI = this.right.getRoSI(signal.subWord(i));
+            RoSI reducedRoSI = historyRoSIs.stream().limit(i + 1)
+                    .filter(Objects::nonNull)
+                    .reduce(releasedRoSI, RoSI::max);
+            result.assignMin(reducedRoSI);
         }
         return result;
     }

--- a/core/src/main/java/net/maswag/falcaun/TemporalRelease.java
+++ b/core/src/main/java/net/maswag/falcaun/TemporalRelease.java
@@ -41,7 +41,12 @@ public class TemporalRelease<I> extends AbstractTemporalLogic<I> {
         // !(max_i (!q_i && (!p_0 && !p_1 && ... && !p_i)))
         // = (min_i (q_i || (p_0 || p_1 || ... || p_i)))
         RoSI result = new RoSI(Double.POSITIVE_INFINITY, Double.POSITIVE_INFINITY);
-
+        // The semantics of the Release operator (p R q) is:
+        // min_i (q_i || (p_0 || p_1 || ... || p_i)),
+        // where p_i is the RoSI of the left formula at the i-th prefix of the signal,
+        // and q_i is the RoSI of the right formula at the i-th prefix of the signal.
+        // This follows from the equivalence: p R q ≡ !((!p) U (!q)).
+        RoSI result = new RoSI(Double.POSITIVE_INFINITY, Double.POSITIVE_INFINITY);
         // Take the suffixes of signal in the longest-first order and compute their RoSI.
         List<RoSI> historyRoSIs = signal.suffixes(true).stream().map(this.left::getRoSI).toList();
         for (int i = 0; i < signal.length(); i++) {

--- a/core/src/test/java/net/maswag/falcaun/IOSignalGenerator.java
+++ b/core/src/test/java/net/maswag/falcaun/IOSignalGenerator.java
@@ -1,0 +1,32 @@
+package net.maswag.falcaun;
+
+import com.pholser.junit.quickcheck.generator.GenerationStatus;
+import com.pholser.junit.quickcheck.generator.Generator;
+import com.pholser.junit.quickcheck.random.SourceOfRandomness;
+import net.automatalib.word.WordBuilder;
+
+import java.util.Collections;
+import java.util.List;
+
+public class IOSignalGenerator extends Generator<IOSignal> {
+    public IOSignalGenerator() {
+        super(IOSignal.class);
+    }
+
+    @Override
+    public IOSignal<List<Double>> generate(SourceOfRandomness random, GenerationStatus status) {
+        IOSignal<List<Double>> signal;
+
+        int size = random.nextInt(32);
+        WordBuilder<List<Double>> inputBuilder = new WordBuilder<>();
+        WordBuilder<List<Double>> outputBuilder = new WordBuilder<>();
+
+        for (int i = 0; i < size; i++) {
+            inputBuilder.append(Collections.singletonList((random.nextDouble() - 0.5) * 2000));
+            outputBuilder.append(Collections.singletonList((random.nextDouble() - 0.5) * 2000));
+        }
+        signal = new IODiscreteSignal<>(inputBuilder.toWord(), outputBuilder.toWord());
+        assert signal.size() == size;
+        return signal;
+    }
+}

--- a/core/src/test/java/net/maswag/falcaun/STLReleaseTest.java
+++ b/core/src/test/java/net/maswag/falcaun/STLReleaseTest.java
@@ -1,0 +1,43 @@
+package net.maswag.falcaun;
+
+import com.pholser.junit.quickcheck.From;
+import com.pholser.junit.quickcheck.Property;
+import com.pholser.junit.quickcheck.runner.JUnitQuickcheck;
+import net.maswag.falcaun.TemporalGlobally.STLGlobally;
+import net.maswag.falcaun.TemporalLogic.STLCost;
+import net.maswag.falcaun.TemporalRelease.STLRelease;
+import net.maswag.falcaun.TemporalUntil.STLUntil;
+import net.maswag.falcaun.TemporalNot.STLNot;
+import org.junit.runner.RunWith;
+
+import java.util.List;
+
+import static java.lang.Double.POSITIVE_INFINITY;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+@RunWith(JUnitQuickcheck.class)
+public class STLReleaseTest {
+    @Property
+    public void releaseGlobally(@From(IOSignalGenerator.class) IOSignal<List<Double>> signal) {
+        STLCost release = new STLRelease(new STLOutputAtomic(0, STLOutputAtomic.Operation.gt, POSITIVE_INFINITY),
+                new STLOutputAtomic(0, STLOutputAtomic.Operation.gt, 0));
+        STLCost globally = new STLGlobally(new STLOutputAtomic(0, STLOutputAtomic.Operation.gt, 0));
+        RoSI releaseRoSI = release.getRoSI(signal);
+        RoSI globallyRoSI = globally.getRoSI(signal);
+        assertEquals(globallyRoSI.upperBound, releaseRoSI.upperBound);
+        assertEquals(globallyRoSI.lowerBound, releaseRoSI.lowerBound);
+    }
+
+    @Property
+    public void releaseUntil(@From(IOSignalGenerator.class) IOSignal<List<Double>> signal) {
+        STLCost release = new STLRelease(new STLInputAtomic(0, STLOutputAtomic.Operation.lt, 0),
+                new STLOutputAtomic(0, STLOutputAtomic.Operation.gt, 0));
+        STLCost until = new STLNot(new STLUntil(
+                new STLNot(new STLInputAtomic(0, STLOutputAtomic.Operation.lt, 0)),
+                new STLNot(new STLOutputAtomic(0, STLOutputAtomic.Operation.gt, 0))));
+        RoSI releaseRoSI = release.getRoSI(signal);
+        RoSI untilRoSI = until.getRoSI(signal);
+        assertEquals(untilRoSI.upperBound, releaseRoSI.upperBound);
+        assertEquals(untilRoSI.lowerBound, releaseRoSI.lowerBound);
+    }
+}

--- a/core/src/test/java/net/maswag/falcaun/STLReleaseTest.java
+++ b/core/src/test/java/net/maswag/falcaun/STLReleaseTest.java
@@ -33,7 +33,10 @@ public class STLReleaseTest {
         STLCost release = new STLRelease(new STLInputAtomic(0, STLOutputAtomic.Operation.lt, 0),
                 new STLOutputAtomic(0, STLOutputAtomic.Operation.gt, 0));
         STLCost until = new STLNot(new STLUntil(
-                new STLNot(new STLInputAtomic(0, STLOutputAtomic.Operation.lt, 0)),
+        STLCost release = new STLRelease(new STLInputAtomic(0, STLInputAtomic.Operation.lt, 0),
+                new STLOutputAtomic(0, STLOutputAtomic.Operation.gt, 0));
+        STLCost until = new STLNot(new STLUntil(
+                new STLNot(new STLInputAtomic(0, STLInputAtomic.Operation.lt, 0)),
                 new STLNot(new STLOutputAtomic(0, STLOutputAtomic.Operation.gt, 0))));
         RoSI releaseRoSI = release.getRoSI(signal);
         RoSI untilRoSI = until.getRoSI(signal);

--- a/core/src/test/java/net/maswag/falcaun/STLReleaseTest.java
+++ b/core/src/test/java/net/maswag/falcaun/STLReleaseTest.java
@@ -30,9 +30,6 @@ public class STLReleaseTest {
 
     @Property
     public void releaseUntil(@From(IOSignalGenerator.class) IOSignal<List<Double>> signal) {
-        STLCost release = new STLRelease(new STLInputAtomic(0, STLOutputAtomic.Operation.lt, 0),
-                new STLOutputAtomic(0, STLOutputAtomic.Operation.gt, 0));
-        STLCost until = new STLNot(new STLUntil(
         STLCost release = new STLRelease(new STLInputAtomic(0, STLInputAtomic.Operation.lt, 0),
                 new STLOutputAtomic(0, STLOutputAtomic.Operation.gt, 0));
         STLCost until = new STLNot(new STLUntil(

--- a/core/src/test/java/net/maswag/falcaun/STLUntilTest.java
+++ b/core/src/test/java/net/maswag/falcaun/STLUntilTest.java
@@ -1,39 +1,22 @@
 package net.maswag.falcaun;
 
-import net.automatalib.word.WordBuilder;
+import com.pholser.junit.quickcheck.From;
+import com.pholser.junit.quickcheck.Property;
+import com.pholser.junit.quickcheck.runner.JUnitQuickcheck;
 import net.maswag.falcaun.TemporalEventually.STLEventually;
 import net.maswag.falcaun.TemporalLogic.STLCost;
 import net.maswag.falcaun.TemporalUntil.STLUntil;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
+import org.junit.runner.RunWith;
 
-import java.util.Collections;
 import java.util.List;
-import java.util.Random;
 
 import static java.lang.Double.POSITIVE_INFINITY;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-class STLUntilTest {
-    IOSignal signal;
-
-    @BeforeEach
-    void setUp() {
-        Random random = new Random();
-        int size = random.nextInt(32);
-        WordBuilder<List<Double>> inputBuilder = new WordBuilder<>();
-        WordBuilder<List<Double>> outputBuilder = new WordBuilder<>();
-
-        for (int i = 0; i < size; i++) {
-            inputBuilder.append(Collections.singletonList((random.nextDouble() - 0.5) * 2000));
-            outputBuilder.append(Collections.singletonList((random.nextDouble() - 0.5) * 2000));
-        }
-        signal = new IODiscreteSignal(inputBuilder.toWord(), outputBuilder.toWord());
-        assert signal.size() == size;
-    }
-
-    @Test
-    void UntilEventually() {
+@RunWith(JUnitQuickcheck.class)
+public class STLUntilTest {
+    @Property
+    public void UntilEventually(@From(IOSignalGenerator.class) IOSignal<List<Double>> signal) {
         STLCost until = new STLUntil(new STLOutputAtomic(0, STLOutputAtomic.Operation.lt, POSITIVE_INFINITY),
                 new STLOutputAtomic(0, STLOutputAtomic.Operation.gt, 0));
         STLCost eventually = new STLEventually(new STLOutputAtomic(0, STLOutputAtomic.Operation.gt, 0));


### PR DESCRIPTION
## Summary of the changes

This PR fixes a bug in the robustness of the temporal release operator. This PR also enhances the unit test on the Until operator to use `junit-quickcheck`.

## Checklist

* [X] Are the contributors appropriately acknowledged?
    * [X] in the README.md
    * [X] in the code as JavaDoc comments
    * [X] in the document (site/docs/index.md)
* [X] Is the new functionality tested by a unit test?
    * Please also consider using [junit-quickcheck](https://github.com/pholser/junit-quickcheck) for property-based testing if possible.