### PR TITLE
Add a note to install LTSMin with a newer Spot

### DIFF
--- a/example/kotlin/README.md
+++ b/example/kotlin/README.md
@@ -53,8 +53,8 @@ On Linux, you can likely find suitable directory to set `JAVA_HOME` by `ls /usr/
 ## Note
 ### Installation of LTSMin with a newer Spot
 Some STL properties require building LTSMin by yourself with a newer library.
-For example, the commented-out line in `stlList` in [simglucose2.kts](./simglucose2.kts) applies.
-It is because of a bug in Spot, which LTSMin internally uses.
+For example, the commented-out lines in `stlList` in [simglucose2.kts](./simglucose2.kts) applies.
+It is because of the inefficient old Spot, which LTSMin internally uses.
 
 First, install Spot using https://spot.lre.epita.fr/install.html as a reference.
 


### PR DESCRIPTION
## Summary of the changes
Add the procedure to install LTSMin with a newer Spot version to `example/kotlin/README.md`.
(As described in the note, the newer Spot is required to verify some large LTL formulas like `(input(0) == 50.0 && X (input(0) == 50.0)) R (output(0) < 400.0)`)