### PR TITLE
Align ANTLR plugin with runtime

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -14,7 +14,7 @@
     <artifactId>FalCAuN-core</artifactId>
 
     <properties>
-        <antlr4.version>4.13.2</antlr4.version>
+        <antlr4.version>4.8</antlr4.version>
     </properties>
 
     <build>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -13,6 +13,10 @@
 
     <artifactId>FalCAuN-core</artifactId>
 
+    <properties>
+        <antlr4.version>4.13.2</antlr4.version>
+    </properties>
+
     <build>
         <plugins>
             <!-- Copying project dependencies: https://maven.apache.org/plugins/maven-dependency-plugin/examples/copying-project-dependencies.html -->
@@ -92,7 +96,7 @@
             <plugin>
                 <groupId>org.antlr</groupId>
                 <artifactId>antlr4-maven-plugin</artifactId>
-                <version>4.9.3</version>
+                <version>${antlr4.version}</version>
                 <executions>
                     <execution>
                         <id>antlr</id>
@@ -129,7 +133,7 @@
         <dependency>
             <groupId>org.antlr</groupId>
             <artifactId>antlr4-runtime</artifactId>
-            <version>4.13.2</version>
+            <version>${antlr4.version}</version>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
## Summary
- add a shared `antlr4.version` property set to 4.13.2
- apply the property to both the ANTLR Maven plugin and runtime dependency to keep versions aligned after the upgrade

## Testing
- mvn -pl core -am -DskipTests compile

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69575da7594083329169d0e49807feeb)