### PR TITLE
Replace flaky Simulink timeout test with deterministic core test

### DIFF
--- a/core/src/main/java/net/maswag/falcaun/TimeoutEQOracle.java
+++ b/core/src/main/java/net/maswag/falcaun/TimeoutEQOracle.java
@@ -9,6 +9,8 @@ import org.slf4j.LoggerFactory;
 
 import org.jetbrains.annotations.Nullable;
 import java.util.Collection;
+import java.util.concurrent.TimeUnit;
+import java.util.function.LongSupplier;
 
 /**
  * Am equivalence oracle to add timeout in addition to the original oracle.
@@ -20,31 +22,37 @@ import java.util.Collection;
 public class TimeoutEQOracle<I, O> implements EquivalenceOracle.MealyEquivalenceOracle<I, O> {
     private static final Logger LOGGER = LoggerFactory.getLogger(TimeoutEQOracle.class);
 
-    private long timeout;
+    private final long timeout;
     private long startTime;
-    private MealyEquivalenceOracle<I, O> eqOracle;
+    private final MealyEquivalenceOracle<I, O> eqOracle;
+    private final LongSupplier nanoTime;
 
     /**
      * @param eqOracle the wrapped equivalence oracle
      * @param timeout  timeout in seconds.
      */
     TimeoutEQOracle(MealyEquivalenceOracle<I, O> eqOracle, long timeout) {
+        this(eqOracle, timeout, System::nanoTime);
+    }
+
+    TimeoutEQOracle(MealyEquivalenceOracle<I, O> eqOracle, long timeout, LongSupplier nanoTime) {
         this.eqOracle = eqOracle;
-        this.timeout = timeout * 1000000000;
+        this.timeout = TimeUnit.SECONDS.toNanos(timeout);
+        this.nanoTime = nanoTime;
     }
 
     /**
      * Start ticking the clock
      */
     void start() {
-        startTime = System.nanoTime();
+        startTime = nanoTime.getAsLong();
     }
 
     /** {@inheritDoc} */
     @Nullable
     @Override
     public DefaultQuery<I, Word<O>> findCounterExample(MealyMachine<?, I, ?, O> objects, Collection<? extends I> collection) {
-        if ((System.nanoTime() - startTime) > timeout) {
+        if ((nanoTime.getAsLong() - startTime) > timeout) {
             LOGGER.info("EQQuery finished because of timeout!!");
             return null;
         } else {

--- a/core/src/main/java/net/maswag/falcaun/TimeoutEQOracle.java
+++ b/core/src/main/java/net/maswag/falcaun/TimeoutEQOracle.java
@@ -25,6 +25,12 @@ public class TimeoutEQOracle<I, O> implements EquivalenceOracle.MealyEquivalence
     private final long timeout;
     private long startTime;
     private final MealyEquivalenceOracle<I, O> eqOracle;
+    /**
+     * Clock supplier for reading the current time.
+     * In production this is {@link System#nanoTime()}; for testing it may be a fake
+     * clock (e.g. returning synthetic nanosecond values) so that timeout behaviour
+     * can be verified without sleeping or wall-clock timing.
+     */
     private final LongSupplier nanoTime;
 
     /**
@@ -35,6 +41,15 @@ public class TimeoutEQOracle<I, O> implements EquivalenceOracle.MealyEquivalence
         this(eqOracle, timeout, System::nanoTime);
     }
 
+    /**
+     * @param eqOracle the wrapped equivalence oracle
+     * @param timeout  timeout in seconds.
+     * @param nanoTime a {@link LongSupplier} that returns current time in nanoseconds.
+     *                 In production this is typically {@code System::nanoTime};
+     *                 for testing provide a fake clock that returns controllable values
+     *                 (e.g. {@code () -> fakeClockValue}) so timeout behaviour can be
+     *                 verified without sleeping or wall-clock timing.
+     */
     TimeoutEQOracle(MealyEquivalenceOracle<I, O> eqOracle, long timeout, LongSupplier nanoTime) {
         this.eqOracle = eqOracle;
         this.timeout = TimeUnit.SECONDS.toNanos(timeout);

--- a/core/src/test/java/net/maswag/falcaun/TimeoutEQOracleTest.java
+++ b/core/src/test/java/net/maswag/falcaun/TimeoutEQOracleTest.java
@@ -1,0 +1,73 @@
+package net.maswag.falcaun;
+
+import de.learnlib.oracle.EquivalenceOracle.MealyEquivalenceOracle;
+import de.learnlib.query.DefaultQuery;
+import net.automatalib.automaton.transducer.MealyMachine;
+import net.automatalib.word.Word;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.Collection;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+class TimeoutEQOracleTest {
+
+    @BeforeEach
+    void setUp() {
+        // no setup needed - each test creates its own instances
+    }
+
+    @Test
+    void beforeTimeout_delegatesToOracle() {
+        @SuppressWarnings("unchecked")
+        MealyEquivalenceOracle<String, String> wrappedOracle = mock(MealyEquivalenceOracle.class);
+
+        long[] fakeClock = {0};
+        TimeoutEQOracle<String, String> timeoutOracle =
+                new TimeoutEQOracle<>(wrappedOracle, 120, () -> fakeClock[0]);
+
+        timeoutOracle.start();
+        fakeClock[0] = 100_000_000_000L; // 100 seconds
+
+        DefaultQuery<String, Word<String>> result = timeoutOracle.findCounterExample(null, null);
+
+        verify(wrappedOracle).findCounterExample(isNull(), isNull());
+    }
+
+    @Test
+    void atTimeoutBoundary_delegatesToOracle() {
+        @SuppressWarnings("unchecked")
+        MealyEquivalenceOracle<String, String> wrappedOracle = mock(MealyEquivalenceOracle.class);
+
+        long[] fakeClock = {0};
+        TimeoutEQOracle<String, String> timeoutOracle =
+                new TimeoutEQOracle<>(wrappedOracle, 120, () -> fakeClock[0]);
+
+        timeoutOracle.start();
+        fakeClock[0] = 120_000_000_000L; // exactly 120 seconds
+
+        timeoutOracle.findCounterExample(null, null);
+
+        verify(wrappedOracle).findCounterExample(isNull(), isNull());
+    }
+
+    @Test
+    void afterTimeout_returnsNull() {
+        @SuppressWarnings("unchecked")
+        MealyEquivalenceOracle<String, String> wrappedOracle = mock(MealyEquivalenceOracle.class);
+
+        long[] fakeClock = {0};
+        TimeoutEQOracle<String, String> timeoutOracle =
+                new TimeoutEQOracle<>(wrappedOracle, 120, () -> fakeClock[0]);
+
+        timeoutOracle.start();
+        fakeClock[0] = 121_000_000_000L; // 121 seconds
+
+        DefaultQuery<String, Word<String>> result = timeoutOracle.findCounterExample(null, null);
+
+        assertNull(result);
+        verifyNoInteractions(wrappedOracle);
+    }
+}

--- a/matlab/src/test/java/net/maswag/falcaun/simulink/SimulinkSULVerifierTest.java
+++ b/matlab/src/test/java/net/maswag/falcaun/simulink/SimulinkSULVerifierTest.java
@@ -22,7 +22,6 @@ import java.util.stream.Collectors;
 import static java.lang.Math.abs;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsInAnyOrder;
-import static org.hamcrest.Matchers.greaterThan;
 import static org.junit.jupiter.api.Assertions.*;
 
 class SimulinkSULVerifierTest {
@@ -316,26 +315,6 @@ class SimulinkSULVerifierTest {
                 largest = new ArrayList<>(Arrays.asList('b', 'c', 'a'));
             }
             mapper = new NumericSULMapper(inputMapper, largest, outputMapper, new SimpleSignalMapper(sigMap));
-        }
-
-        @Test
-        void setTimeout() throws Exception {
-            // generate properties
-            String stlString = "alw_[0, 3] (signal(1) < 6000)";
-            TemporalLogic.STLCost stl = factory.parse(stlString, inputMapper, outputMapper, largest);
-            properties = new StaticSTLList<>(Collections.singletonList(stl));
-            // define the verifier
-            verifier = new SimulinkSULVerifier(initScript, paramNames, signalStep, 0.0025, properties, mapper);
-            // set timeout
-            long timeout = 2 * 60;
-            verifier.setTimeout(timeout);
-            // add equivalence oracle
-            verifier.addGAEQOracleAll(25, 1000, GASelectionKind.Tournament,
-                    50, 0.9, 0.01);
-            long startTime = System.nanoTime();
-            assertTrue(verifier.run());
-            long duration = (System.nanoTime() - startTime) / 1000 / 1000 / 1000;
-            assertThat("Execution time", duration, greaterThan(timeout));
         }
 
         @Nested


### PR DESCRIPTION
## Summary

The current timeout test in `SimulinkSULVerifierTest.AutoTransTest.setTimeout` is flaky because it asserts wall-clock execution time. This PR moves the timeout behavior test into the core module where it can be tested deterministically.

### Changes

1. **Remove flaky test** — Deleted `@Test void setTimeout()` from `SimulinkSULVerifierTest.AutoTransTest` and the unused `greaterThan` import.

2. **Refactor `TimeoutEQOracle`** — Added a package-private constructor accepting a `LongSupplier` clock parameter, enabling deterministic testing without sleeping or wall-clock timing:
   - Production constructor delegates with `System::nanoTime`
   - Uses `TimeUnit.SECONDS.toNanos(timeout)` instead of manual multiplication
   - Added Javadoc explaining the clock parameter and expected values

3. **New core test** — `TimeoutEQOracleTest` with 3 deterministic tests:
   - `beforeTimeout_delegatesToOracle()` — fake time at 100s verifies oracle is called
   - `atTimeoutBoundary_delegatesToOracle()` — fake time at exactly 120s preserves `>` semantics
   - `afterTimeout_returnsNull()` — fake time at 121s returns null, oracle not called

### Test results

| Module   | Tests | Failures |
|------ ----|----- --|----- ---- |
| core     | 173   | 0        |
| matlab   | 5*    | 0        |

*\*Remaining Simulink tests require MATLAB runtime and time out.